### PR TITLE
Potential fix for code scanning alert no. 4: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,8 @@
     "wouter": "^3.3.5",
     "ws": "^8.18.0",
     "zod": "^3.24.2",
-    "zod-validation-error": "^3.4.0"
+    "zod-validation-error": "^3.4.0",
+    "express-rate-limit": "^7.5.1"
   },
   "devDependencies": {
     "@replit/vite-plugin-cartographer": "^0.2.7",

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -1,3 +1,4 @@
+import rateLimit from "express-rate-limit";
 import express, { type Express } from "express";
 import fs from "fs";
 import path from "path";
@@ -78,8 +79,14 @@ export function serveStatic(app: Express) {
 
   app.use(express.static(distPath));
 
+  // rate limiter: maximum of 100 requests per minute
+  const rateLimiter = require("express-rate-limit")({
+    windowMs: 1 * 60 * 1000, // 1 minute
+    max: 100, // limit each IP to 100 requests per windowMs
+  });
+
   // fall through to index.html if the file doesn't exist
-  app.use("*", (_req, res) => {
+  app.use("*", rateLimiter, (_req, res) => {
     res.sendFile(path.resolve(distPath, "index.html"));
   });
 }


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/SpiralParserEngine/security/code-scanning/4](https://github.com/CreoDAMO/SpiralParserEngine/security/code-scanning/4)

To fix the issue, we will introduce rate limiting to the route handler flagged by CodeQL. The `express-rate-limit` package will be used to enforce rate limiting directly in the application. This package allows us to define a maximum number of requests per time window, protecting the server from excessive requests.

Steps for the fix:
1. Install and import the `express-rate-limit` package.
2. Configure a rate limiter with appropriate settings (e.g., maximum requests per minute).
3. Apply the rate limiter middleware specifically to the route handler flagged by CodeQL.

This ensures the application can handle requests efficiently while preventing potential DoS attacks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
