### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generate-languages.yml
+++ b/.github/workflows/generate-languages.yml
@@ -1,6 +1,9 @@
 
 name: Generate Language Support
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main, develop ]
@@ -14,6 +17,8 @@ on:
 jobs:
   generate-languages:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     
     steps:
     - name: Checkout repository
@@ -62,6 +67,8 @@ jobs:
   validate-parsing:
     runs-on: ubuntu-latest
     needs: generate-languages
+    permissions:
+      contents: read
     
     steps:
     - name: Checkout repository


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/SpiralParserEngine/security/code-scanning/2](https://github.com/CreoDAMO/SpiralParserEngine/security/code-scanning/2)

To address the issue, explicit `permissions` blocks should be added to the workflow. For jobs that perform read-only operations (e.g., `validate-parsing`), minimal permissions such as `contents: read` should be set. For jobs that require write operations (e.g., `generate-languages`), permissions should be appropriately scoped (e.g., `contents: write`). This prevents the GITHUB_TOKEN from inheriting broader repository permissions unnecessarily.

Changes will be made to the `.github/workflows/generate-languages.yml` file:
1. Add a root-level `permissions` block to restrict default permissions for all jobs (e.g., `contents: read`).
2. Add job-specific `permissions` blocks where necessary:
   - `generate-languages`: Requires `contents: write` for committing changes.
   - `validate-parsing`: Requires only `contents: read`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
