### PR TITLE
Potential fix for code scanning alert no. 3: Missing rate limiting

### DIFF
--- a/server/vite.ts
+++ b/server/vite.ts
@@ -42,7 +42,13 @@ export async function setupVite(app: Express, server: Server) {
   });
 
   app.use(vite.middlewares);
-  app.use("*", async (req, res, next) => {
+  // rate limiter: maximum of 100 requests per minute
+  const rateLimiter = rateLimit({
+    windowMs: 1 * 60 * 1000, // 1 minute
+    max: 100, // limit each IP to 100 requests per windowMs
+  });
+
+  app.use("*", rateLimiter, async (req, res, next) => {
     const url = req.originalUrl;
 
     try {


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/SpiralParserEngine/security/code-scanning/3](https://github.com/CreoDAMO/SpiralParserEngine/security/code-scanning/3)

To fix the issue, a rate-limiting middleware should be applied to the route handler on line 45. This can be done using the `express-rate-limit` package already imported into the file. A rate limiter can be configured to limit the number of requests per minute (e.g., 100 requests per minute) for this specific endpoint.

Changes required:
1. Define a rate limiter instance with a reasonable configuration (e.g., `max: 100` and `windowMs: 1 minute`).
2. Apply the rate limiter middleware to the route handler on line 45.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
