### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generate-languages.yml
+++ b/.github/workflows/generate-languages.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: write
+
 jobs:
   generate-languages:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/SpiralParserEngine/security/code-scanning/6](https://github.com/CreoDAMO/SpiralParserEngine/security/code-scanning/6)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's steps:
- `contents: read` is required for reading repository files.
- `contents: write` is required for committing and pushing changes to the repository.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or specifically to the `generate-languages` job. Adding it at the root level is more concise and ensures consistency across jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
